### PR TITLE
Update target of python3 symlink

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -109,7 +109,7 @@
       become: true
     - name: Set up python3 link (Redhat)
       file:
-        src: /usr/bin/python36
+        src: /usr/bin/python3.6
         dest: /usr/bin/python3
         state: link
       become: true


### PR DESCRIPTION
In recent releases of RedHat 7 and CentOS 7 this binary is now called
`python3.6` rather than `python36`.