### PR TITLE
Update target of python3 symlink. [1.21 cherry-pick]

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -109,7 +109,7 @@
       become: true
     - name: Set up python3 link (Redhat)
       file:
-        src: /usr/bin/python36
+        src: /usr/bin/python3.6
         dest: /usr/bin/python3
         state: link
       become: true


### PR DESCRIPTION
This issue also affects 1.21 so should be backported.