### PR TITLE
Update setting of external URL

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -150,6 +150,11 @@
         src: templates/integrations.json
         dest: /tmp/lgtm-install/integrations.json
         mode: 0400
+    - name: Copy LGTM server configuration
+      template:
+        src: templates/server.json
+        dest: /tmp/lgtm-install/server.json
+        mode: 0400
     - name: Start core services
       command: lgtm-up --core-only
       become: true
@@ -176,6 +181,9 @@
       become: true
     - name: Configure integrations
       command: lgtm-cli patch-config /tmp/lgtm-install/integrations.json
+      become: true
+    - name: Configure web server
+      command: lgtm-cli patch-config /tmp/lgtm-install/server.json
       become: true
 
 - name: Start LGTM

--- a/templates/lgtm-cluster-config.yml
+++ b/templates/lgtm-cluster-config.yml
@@ -12,7 +12,6 @@ search:
 web:
   hosts:
   - hostname: "dummy-web"
-  external_url: "{{ lgtm_external_url }}/"
   ssl:
     certificate_path: "server.crt"
     key_path: "server.key"

--- a/templates/server.json
+++ b/templates/server.json
@@ -1,0 +1,5 @@
+{
+  "server" : {
+    "url" : "{{ lgtm_external_url }}/"
+  }
+}


### PR DESCRIPTION
In 1.23 this has moved out of the cluster configuration file, and is
set as a post-installation step.

