### PR TITLE
Fix Ubuntu 20.04 LTS, Debian 10, and package transfer speed

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -69,12 +69,18 @@
         src: "{{ lgtm_key_file }}"
         dest: /tmp/lgtm-install/state/server.key
         mode: 0400
-    - name: Install Java (deb)
+    - name: Install Java 8 (deb)
       apt:
         name: openjdk-8-jre-headless
         state: latest
       become: true
-      when: ansible_os_family == 'Debian'
+      when: "ansible_os_family == 'Debian' and ansible_distribution_major_version != '10'"
+    - name: Install Java 11 (deb)
+      apt:
+        name: openjdk-11-jre-headless
+        state: latest
+      become: true
+      when: ansible_os_family == 'Debian' and ansible_distribution_major_version == "10"
     - name: Install Java (rpm)
       yum:
         name: java-1.8.0-openjdk-headless
@@ -101,7 +107,7 @@
   hosts: worker
   tags: buildtools
   tasks:
-    - name: Install build packages (Debian only)
+    - name: Install build packages (Debian/Ubuntu)
       apt:
         name:
         - openjdk-8-jdk-headless
@@ -109,7 +115,16 @@
         - python3-pip
         state: latest
       become: true
-      when: ansible_os_family == 'Debian'
+      when: "ansible_os_family == 'Debian' and ansible_distribution_major_version != '10'"
+    - name: Install build packages (Debian 10 only)
+      apt:
+        name:
+        - openjdk-11-jdk-headless
+        - gradle
+        - python3-pip
+        state: latest
+      become: true
+      when: ansible_os_family == 'Debian' and ansible_distribution_major_version == "10"
     - name: Install build packages (RedHat only)
       yum:
         name:

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
-- name: Copy LGTM packages
-  hosts: all
+- name: Copy LGTM packages (controller)
+  hosts: controller
   gather_facts: true
   tags: packages
   tasks:
@@ -18,6 +18,29 @@
         dest: /tmp/lgtm-install/lgtm
         delete: true
         recursive: true
+
+- name: Copy LGTM packages (non-controllers)
+  hosts: all:!controller
+  gather_facts: true
+  tags: packages
+  tasks:
+    - name: Install rsync
+      package:
+        name: rsync
+        state: latest
+      become: true
+    - name: Create temporary directory
+      file:
+        path: /tmp/lgtm-install
+        state: directory
+    - name: Download lgtm
+      synchronize:
+        src: files/lgtm/
+        dest: /tmp/lgtm-install/lgtm
+        delete: true
+        recursive: true
+        rsync_opts:
+          - '--exclude=lgtm-upgrade*'
 
 - name: Generate configuration files
   hosts: all

--- a/site.yml
+++ b/site.yml
@@ -142,9 +142,15 @@
         - clang
         - gcc
         - mono-devel
+        state: latest
+      become: true
+    - name: Install python-pip
+      package:
+        name:
         - python-pip
         state: latest
       become: true
+      when: "ansible_distribution != 'Ubuntu' or ansible_distribution_major_version != '20'"
     - name: Set up python3 link (Redhat)
       file:
         src: /usr/bin/python3.6
@@ -155,6 +161,7 @@
     - name: Install Python 2 pip packages
       command: pip install packaging virtualenv
       become: true
+      when: "ansible_distribution != 'Ubuntu' or ansible_distribution_major_version != '20'"
     - name: Install Python 3 pip packages
       command: pip3 install packaging virtualenv
       become: true


### PR DESCRIPTION
Fix three issues found in testing by:
- skipping Python 2 tooling on Ubuntu 20.04 LTS (it doesn't include Python 2 tools)
- using Java 11 on Debian 10
- only copying the large `lgtm-upgrade` package to the controller