### PR TITLE
Work around a bug in recent versions of Ansible.

### DIFF
--- a/templates/git-credentials
+++ b/templates/git-credentials
@@ -1,1 +1,1 @@
-https://{{ lgtm_ghe_checkout_username | urlencode() }}:{{ lgtm_ghe_checkout_token | urlencode() }}@{{ lgtm_ghe_hostname }}
+https://{{ lgtm_ghe_checkout_username | string | urlencode() }}:{{ lgtm_ghe_checkout_token | string | urlencode() }}@{{ lgtm_ghe_hostname }}


### PR DESCRIPTION
When deploying LGTM currently with the latest Ansible version, rendering this template will currently fail with the cryptic error:

> ValueError: not enough values to unpack (expected 2, got 1)

This seems to be because `lgtm_ghe_checkout_username` and `lgtm_ghe_checkout_token` are not strings as you might expect but are instead `AnsibleVaultEncryptedUnicode` values. The `urlencode` filter seems to have previously been able to cope with these but now crashes instead. This can be worked around by decrypting them to strings manually before escaping them.