### PR TITLE
Don't upgrade Java 8 on CentOS/RHEL automatically.

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -84,7 +84,7 @@
     - name: Install Java (rpm)
       yum:
         name: java-1.8.0-openjdk-headless
-        state: latest
+        state: present
       become: true
       when: ansible_os_family == 'RedHat'
     - name: Run config generation


### PR DESCRIPTION
This allows working around a Java issue by installing a slightly older version of Java before running the playbook.