### PR TITLE
Stop installing requirements for analyzing Python 2.

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -144,13 +144,6 @@
         - mono-devel
         state: latest
       become: true
-    - name: Install python-pip
-      package:
-        name:
-        - python-pip
-        state: latest
-      become: true
-      when: "ansible_distribution != 'Ubuntu' or ansible_distribution_major_version != '20'"
     - name: Set up python3 link (Redhat)
       file:
         src: /usr/bin/python3.6
@@ -158,10 +151,6 @@
         state: link
       become: true
       when: ansible_os_family == 'RedHat'
-    - name: Install Python 2 pip packages
-      command: pip install packaging virtualenv
-      become: true
-      when: "ansible_distribution != 'Ubuntu' or ansible_distribution_major_version != '20'"
     - name: Install Python 3 pip packages
       command: pip3 install packaging virtualenv
       become: true


### PR DESCRIPTION
Python 2 has been deprecated for quite a while, and setting up the dependencies for it has become increasingly difficult. These steps for example no longer work.

I think at this point we can probably just remove the built-in Python 2 support; in the unlikely event people still need it they should be able to configure it themselves.